### PR TITLE
ci: Ignore update for rubocop gem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "rubocop"


### PR DESCRIPTION
We do not need update `rubocop` by `dependabot` until we modify the rule of grammer check manually.